### PR TITLE
Lambdas instead of do notation

### DIFF
--- a/haskell/actual/ESE20181204.hs
+++ b/haskell/actual/ESE20181204.hs
@@ -57,6 +57,16 @@ module ESE20181204 where
                            xs1 <- mapListM f xs
                            return (x1:xs1)
 
+-- mapListM done with lambdas instead of do notation
+    mapListM2 :: (t -> State st a) -> [t] -> State st [a]
+    mapListM2 f [] = State(\s -> ([], s))
+    mapListM2 f (x:xs) = State runState where
+            runState s = ((a:as), s'') where
+                (State rs1) = f x
+                (State rs2) = (mapListM2 f xs)
+                (a, s') = rs1 s
+                (as, s'') = rs2 s'
+
 
 -- Define the monadic function 
 -- numberList :: Num st => [st] -> State st [(st, st)],
@@ -73,7 +83,26 @@ module ESE20181204 where
         helper x = do st <- get
                       put (x + st)
                       return (x, x+st)
+
+-- numberList done with lambdas instead of do notation
+    numberList2 :: (Num st) => [st] -> State st [(st, st)]
+    numberList2 l = mapListM helper l where
+        helper x = State(\s -> ((x, s+x), s+x))
+
+-- numberList done using the lambda version of the mapListM function (for testing purposes)
+    numberList3 :: (Num st) => [st] -> State st [(st, st)]
+    numberList3 l = mapListM2 helper l where
+        helper x = State(\s -> ((x, s+x), s+x))
+
+-- Additional helper function useful for debugging and printing
+    doComputations :: (State st a) -> st -> (a, st)
+    doComputations (State runState) initialState = runState initialState
         
+-- TEST: 
+--        doComputations (numberList [1,2,3,4,5]) 0
+--        doComputations (numberList2 [1,2,3,4,5]) 0
+--        doComputations (numberList3 [1,2,3,4,5]) 0
+--          should all yield as a result    ([(1,1),(2,3),(3,6),(4,10),(5,15)],15)
 
     data Tree a = Leaf a | Branch ( Tree a ) ( Tree a )
 


### PR DESCRIPTION
I have implemented an alternative version of the functions mapListM and numberList that make use of explicit lambdas for building runStates that are then wrapped into States, instead of using the do notation. I have briefly tested them and they seem to work and yield the same results.